### PR TITLE
Make default retry count configurable

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -9,7 +9,6 @@ module RSpec
         config.add_setting :default_retry_count, :default => 1
         config.around(:each) do |example|
           retry_count = example.metadata[:retry] || RSpec.configuration.default_retry_count
-          puts "retry count for this puppy is #{retry_count}"
           retry_count.times do |i|
             if RSpec.configuration.verbose_retry?
               if i > 0


### PR DESCRIPTION
For some test suites (e.g. integration tests against flakey third-party services) you may want all tests to be retried a few times by default. This change allows that to be done inside an RSpec.configure block.
