### PR TITLE
Added feature to clear lets after a failure.

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -7,8 +7,14 @@ module RSpec
       RSpec.configure do |config|
         config.add_setting :verbose_retry, :default => false
         config.add_setting :default_retry_count, :default => 1
+        config.add_setting :clear_lets_on_failure, :default => true
+        
         config.around(:each) do |example|
           retry_count = example.metadata[:retry] || RSpec.configuration.default_retry_count
+          
+          clear_lets = example.metadata[:clear_lets_on_failure]
+          clear_lets = RSpec.configuration.clear_lets_on_failure if clear_lets.nil?
+          
           retry_count.times do |i|
             if RSpec.configuration.verbose_retry?
               if i > 0
@@ -19,7 +25,10 @@ module RSpec
             end
             @example.clear_exception
             example.run
+            
             break if @example.exception.nil?
+              
+            self.clear_lets if clear_lets
           end
         end
       end

--- a/lib/rspec_ext/rspec_ext.rb
+++ b/lib/rspec_ext/rspec_ext.rb
@@ -7,3 +7,14 @@ module RSpec
     end
   end
 end
+
+module RSpec
+  module Core
+    class ExampleGroup
+      def clear_lets
+        @__memoized = {}
+      end
+    end
+  end
+end
+

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -49,5 +49,26 @@ describe RSpec::Retry do
     it 'should success randomly', :retry => 3 do
       rand(3).should == 1
     end
+    
+  end
+  
+  describe 'clearing lets' do
+    before(:all) do
+      @control = true
+    end
+
+    let(:let_based_on_control) { @control }
+
+    after do
+      @control = false
+    end
+
+    it 'should clear the let when the test fails so it can be reset', :retry => 2 do
+      let_based_on_control.should == false
+    end
+      
+    it 'should not clear the let when the test fails', :retry => 2, :clear_lets_on_failure => false do
+      let_based_on_control.should == !@control
+    end  
   end
 end


### PR DESCRIPTION
In some test cases lets need to be unique per test execution. Example is with integration tests: the lets give a username and/or password and the test creates a user. With sometimes flakey third party services the test may fail and upon trying to recreate the user that step fails because of a duplicate username.

Also added a config option to turn off the let clearing. Maybe the default should be false instead of true?
