### PR TITLE
Retry report

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -9,6 +9,7 @@ module RSpec
         config.add_setting :verbose_retry, :default => false
         config.add_setting :default_retry_count, :default => 1
         config.add_setting :clear_lets_on_failure, :default => true
+        callbacks = RSpec.configuration.formatters.map{|f| f if f.respond_to? :retry}.compact! || []
 
         config.around(:each) do |example|
           retry_count = example.metadata[:retry] || RSpec.configuration.default_retry_count
@@ -21,6 +22,10 @@ module RSpec
               if i > 0
                 message = "RSpec::Retry: #{RSpec::Retry.ordinalize(i + 1)} try #{@example.location}"
                 message = "\n" + message if i == 1
+                RSpec.configuration.formatters.map{|f| f.respond_to? :retry}.each do |f| puts f.inspect end
+                callbacks.each do |callback|
+                  callback.retry(@example)
+                end
                 RSpec.configuration.reporter.message(message)
               end
             end

--- a/lib/rspec/retry/formatter.rb
+++ b/lib/rspec/retry/formatter.rb
@@ -1,0 +1,41 @@
+require "rspec/core/formatters/base_text_formatter"
+
+class RSpec::Retry::Formatter < RSpec::Core::Formatters::BaseTextFormatter
+  def initialize(output)
+    super(output)
+    @tries = {}
+  end
+
+  def dump_summary(duration, example_count, failure_count, pending_count)
+    output << "\nRSpec Retry Summary:\n"
+    @tries.each do |key, retry_data|
+      next unless retry_data[:tries] > 1
+      output << "\t" << key << ": " << retry_data[:successes].to_s << ' out of ' << retry_data[:tries] << " attempts passed.\n"
+    end
+    output << @tries.count << ' of ' <<  example_count << " tests were retried.\n"
+    output <<  failure_count << " tests failed all retries.\n"
+  end
+
+  def example_started(example)
+    @tries[example.description] = {:successes => 0, :tries => 1}
+  end
+
+  def example_passed(example)
+    increment_success example
+  end
+
+  def retry(example)
+    increment_tries example
+  end
+
+  private
+  def increment_success(example)
+    previous = @tries[example.description]
+    @tries[example.description] = {:successes => (previous[:successes] +1), :tries => previous[:tries]}
+  end
+
+  def increment_tries(example)
+    previous = @tries[example.description]
+    @tries[example.description] = {:successes => previous[:successes], :tries => (previous[:tries] + 1)}
+  end
+end


### PR DESCRIPTION
Admittedly this needs some work - there are no tests and it only works if the documentation formatter is also used.  However, I wanted to send an example of a possible solution for the simplest part of #4 - adding a summary report.

If you run <code>rspec spec/ --format RSpec::Retry::Formatter --format documentation</code> the end of the rspec will be:

<pre>
RSpec Retry Summary:
	should run example until :retry times: 1 out of 3 attempts passed.
	should stop retrying if  example is succeeded: 1 out of 2 attempts passed.
	should clear the let when the test fails so it can be reset: 1 out of 2 attempts passed.
	should not clear the let when the test fails: 1 out of 2 attempts passed.
5 of 5 tests were retried.
0 tests failed all retries.

Finished in 0.0044 seconds
5 examples, 0 failures
</pre>