### PR TITLE
Add the possibility to retry on specific tags

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -41,6 +41,7 @@ module RSpec
               end
             end
             example.clear_exception
+            ex.metadata[:retry_times] = i
             ex.run
 
             break if example.exception.nil?


### PR DESCRIPTION
Hi there @y310, this gem was very handy, thanks! :)

I needed to fork to add the possibility for us retrying just in some specs and don't specify the retry times in all these specs.

This way I can have a `default_retry_count: 5`, but not retry unless one tag is present.

A set of allowed tags can be declared as in:

``` ruby
RSpec.configure do |config|
  config.retry_on_tags = [:search, :ui]
end
```

Opening the PR, perhaps it might interest you :)
