### PR TITLE
Add option to specify Exception to ignore rspec-retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
 - __:default_sleep_interval__(default: *0*) Seconds to wait between retries
 - __:clear_lets_on_failure__(default: *true*) Clear memoized values for ``let``s before retrying
 - __:exceptions_to_retry__(default: *[]*) List of exceptions that will trigger a retry (when empty, all exceptions will)
-- __:exceptions_to_ignore_retry__(default: *[]*) List of exceptions that will ignore rspec-retry and failed only once
+- __:exceptions_to_fail_hard__(default: *[]*) List of exceptions that will ignore rspec-retry and failed only once
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ end
 - __:default_sleep_interval__(default: *0*) Seconds to wait between retries
 - __:clear_lets_on_failure__(default: *true*) Clear memoized values for ``let``s before retrying
 - __:exceptions_to_retry__(default: *[]*) List of exceptions that will trigger a retry (when empty, all exceptions will)
+- __:exceptions_to_ignore_retry__(default: *[]*) List of exceptions that will ignore rspec-retry and failed only once
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ end
 - __:default_sleep_interval__(default: *0*) Seconds to wait between retries
 - __:clear_lets_on_failure__(default: *true*) Clear memoized values for ``let``s before retrying
 - __:exceptions_to_retry__(default: *[]*) List of exceptions that will trigger a retry (when empty, all exceptions will)
-- __:exceptions_to_fail_hard__(default: *[]*) List of exceptions that will ignore rspec-retry and failed only once
+- __:exceptions_to_fail_hard__(default: *[]*) List of exceptions that will ignore rspec-retry and failed only once.  
+This option is useful if you know, that if some specific exception happened - there is no need to retry. [See more](https://github.com/NoRedInk/rspec-retry/pull/26#issuecomment-120265274)
 
 ## Contributing
 

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -16,7 +16,7 @@ module RSpec
         #
         # If no list of exceptions is provided and 'retry' > 1, we always retry.
         config.add_setting :exceptions_to_retry, :default => []
-        config.add_setting :exceptions_to_ignore, :default => []
+        config.add_setting :exceptions_to_ignore_retry, :default => []
 
         # context.example is deprecated, but RSpec.current_example is not
         # available until RSpec 3.0.
@@ -28,7 +28,7 @@ module RSpec
           retry_count = ex.metadata[:retry] || RSpec.configuration.default_retry_count
           sleep_interval = ex.metadata[:retry_wait] || RSpec.configuration.default_sleep_interval
           exceptions_to_retry = ex.metadata[:exceptions_to_retry] || RSpec.configuration.exceptions_to_retry
-          exceptions_to_ignore = ex.metadata[:exceptions_to_ignore] || RSpec.configuration.exceptions_to_ignore
+          exceptions_to_ignore_retry = ex.metadata[:exceptions_to_ignore_retry] || RSpec.configuration.exceptions_to_ignore_retry
 
           clear_lets = ex.metadata[:clear_lets_on_failure]
           clear_lets = RSpec.configuration.clear_lets_on_failure if clear_lets.nil?
@@ -50,8 +50,8 @@ module RSpec
               break unless exceptions_to_retry.include?(example.exception.class)
             end
 
-            if exceptions_to_ignore.any?
-              break if exceptions_to_ignore.include?(example.exception.class)
+            if exceptions_to_ignore_retry.any?
+              break if exceptions_to_ignore_retry.include?(example.exception.class)
             end
 
             self.clear_lets if clear_lets

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -50,9 +50,7 @@ module RSpec
               break unless exceptions_to_retry.include?(example.exception.class)
             end
 
-            if exceptions_to_fail_hard.any?
-              break if exceptions_to_fail_hard.include?(example.exception.class)
-            end
+            break if exceptions_to_fail_hard.include?(example.exception.class)
 
             self.clear_lets if clear_lets
             sleep sleep_interval if sleep_interval.to_i > 0

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -16,7 +16,7 @@ module RSpec
         #
         # If no list of exceptions is provided and 'retry' > 1, we always retry.
         config.add_setting :exceptions_to_retry, :default => []
-        config.add_setting :exceptions_to_ignore_retry, :default => []
+        config.add_setting :exceptions_to_fail_hard, :default => []
 
         # context.example is deprecated, but RSpec.current_example is not
         # available until RSpec 3.0.
@@ -28,7 +28,7 @@ module RSpec
           retry_count = ex.metadata[:retry] || RSpec.configuration.default_retry_count
           sleep_interval = ex.metadata[:retry_wait] || RSpec.configuration.default_sleep_interval
           exceptions_to_retry = ex.metadata[:exceptions_to_retry] || RSpec.configuration.exceptions_to_retry
-          exceptions_to_ignore_retry = ex.metadata[:exceptions_to_ignore_retry] || RSpec.configuration.exceptions_to_ignore_retry
+          exceptions_to_fail_hard = ex.metadata[:exceptions_to_fail_hard] || RSpec.configuration.exceptions_to_fail_hard
 
           clear_lets = ex.metadata[:clear_lets_on_failure]
           clear_lets = RSpec.configuration.clear_lets_on_failure if clear_lets.nil?
@@ -50,8 +50,8 @@ module RSpec
               break unless exceptions_to_retry.include?(example.exception.class)
             end
 
-            if exceptions_to_ignore_retry.any?
-              break if exceptions_to_ignore_retry.include?(example.exception.class)
+            if exceptions_to_fail_hard.any?
+              break if exceptions_to_fail_hard.include?(example.exception.class)
             end
 
             self.clear_lets if clear_lets

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -16,6 +16,7 @@ module RSpec
         #
         # If no list of exceptions is provided and 'retry' > 1, we always retry.
         config.add_setting :exceptions_to_retry, :default => []
+        config.add_setting :exceptions_to_ignore, :default => []
 
         # context.example is deprecated, but RSpec.current_example is not
         # available until RSpec 3.0.
@@ -27,6 +28,7 @@ module RSpec
           retry_count = ex.metadata[:retry] || RSpec.configuration.default_retry_count
           sleep_interval = ex.metadata[:retry_wait] || RSpec.configuration.default_sleep_interval
           exceptions_to_retry = ex.metadata[:exceptions_to_retry] || RSpec.configuration.exceptions_to_retry
+          exceptions_to_ignore = ex.metadata[:exceptions_to_ignore] || RSpec.configuration.exceptions_to_ignore
 
           clear_lets = ex.metadata[:clear_lets_on_failure]
           clear_lets = RSpec.configuration.clear_lets_on_failure if clear_lets.nil?
@@ -46,6 +48,10 @@ module RSpec
 
             if exceptions_to_retry.any?
               break unless exceptions_to_retry.include?(example.exception.class)
+            end
+
+            if exceptions_to_ignore.any?
+              break if exceptions_to_ignore.include?(example.exception.class)
             end
 
             self.clear_lets if clear_lets


### PR DESCRIPTION
This option is usefult if you know, that rspec with some exception failed, but you don't want to add pending to it for some reason. And you have such exception failed it multiple parts of big projects, so to add option `retry: 1` to each case took a lot of time.
Also some part of it looks like option `:exceptions_to_retry`, but now it makes more sence,
because if `:exceptions_to_retry = []` it behave like actually `:excption_to_retry` contains all posible exception classes - for me it some king illogical. 
But `:exceptions_to_ignore_retry` have not such flaw.

Also I tried to write at least single rspec for my option, but could not figure it out how to check it correctly
