### PR TITLE
The environment variable RSPEC_RETRY_RETRY_COUNT can override retry counts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ end
 - __:clear_lets_on_failure__(default: *true*) Clear memoized values for ``let``s before retrying
 - __:exceptions_to_retry__(default: *[]*) List of exceptions that will trigger a retry (when empty, all exceptions will)
 
+## Environment Variables
+- __RSPEC_RETRY_RETRY_COUNT__ can override the retry counts even if a retry count is set in an example or default_retry_count is set in a configuration.
+
 ## Contributing
 
 1. Fork it

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -24,7 +24,9 @@ module RSpec
 
         config.around(:each) do |ex|
           example = fetch_current_example.call(self)
-          retry_count = ex.metadata[:retry] || RSpec.configuration.default_retry_count
+          retry_count = (ENV['RSPEC_RETRY_RETRY_COUNT'] ||
+                         ex.metadata[:retry] ||
+                         RSpec.configuration.default_retry_count).to_i
           sleep_interval = ex.metadata[:retry_wait] || RSpec.configuration.default_sleep_interval
           exceptions_to_retry = ex.metadata[:exceptions_to_retry] || RSpec.configuration.exceptions_to_retry
 

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -19,6 +19,10 @@ describe RSpec::Retry do
     @expectations.shift
   end
 
+  before(:all) do
+    ENV.delete('RSPEC_RETRY_RETRY_COUNT')
+  end
+
   context 'no retry option' do
     it 'should work' do
       expect(true).to be(true)
@@ -43,6 +47,22 @@ describe RSpec::Retry do
       it 'should stop retrying if  example is succeeded', :retry => 3 do
         expect(true).to be(shift_expectation)
         expect(count).to eq(2)
+      end
+    end
+
+    context 'with the environment variable RSPEC_RETRY_RETRY_COUNT' do
+      before(:all) do
+        set_expectations([false, false, true])
+        ENV['RSPEC_RETRY_RETRY_COUNT'] = '3'
+      end
+
+      after(:all) do
+        ENV.delete('RSPEC_RETRY_RETRY_COUNT')
+      end
+
+      it 'should override the retry count set in an example', :retry => 2 do
+        expect(true).to be(shift_expectation)
+        expect(count).to eq(3)
       end
     end
 


### PR DESCRIPTION
This PR addes the feature that the environment variable RSPEC_RETRY_RETRY_COUNT can override retry counts.

This feature is useful when debugging a failed example which take a long time to execute.
