### PR TITLE
Store retry attempts in example metadata.

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -95,7 +95,7 @@ module RSpec
         end
 
         example.metadata[:retry_attempts] = self.attempts
-        # require 'pry'; binding.pry
+
         example.clear_exception
         ex.run
 

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -35,7 +35,7 @@ module RSpec
     # context.example is deprecated, but RSpec.current_example is not
     # available until RSpec 3.0.
     def current_example
-      RSpec.respond_to?(:current_example) ?
+      @current_example ||= RSpec.respond_to?(:current_example) ?
         RSpec.current_example : @ex.example
     end
 
@@ -94,6 +94,8 @@ module RSpec
           end
         end
 
+        example.metadata[:retry_attempts] = self.attempts
+        # require 'pry'; binding.pry
         example.clear_exception
         ex.run
 

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -79,9 +79,30 @@ describe RSpec::Retry do
 
     describe "with a list of exceptions", :retry => 2, :exceptions_to_retry => [NameError] do
       context do
-        let(:example_group) do
-          RSpec.describe('example group', exceptions_to_retry: [NameError], retry: 3).tap do |this|
-            this.run # initialize rspec-retry inside test example group
+        let(:rspec_version) { RSpec::Core::Version::STRING }
+
+        let(:example_code) do
+          %{
+            $count ||= 0
+            $count += 1
+
+            raise NameError unless $count > 2
+          }
+        end
+
+        let!(:example_group) do
+          $count, $example_code = 0, example_code
+
+          RSpec.describe("example group", exceptions_to_retry: [NameError], retry: 3).tap do |this|
+            if rspec_version =~ /^3\.2/
+              this.instance_eval %{
+                it 'intentionally raises an error' do
+                  #{$example_code}
+                end
+              }
+            else
+              this.run # initialize for rspec 3.3+ with no examples
+            end
           end
         end
 
@@ -90,13 +111,12 @@ describe RSpec::Retry do
         end
 
         it 'should retry and match attempts metadata' do
-          example_group.example do
-            $count ||= 0
-            $count += 1
-            raise NameError unless $count > 2
+          unless rspec_version =~ /^3\.2/
+            example_group.example { instance_eval($example_code) }
           end
 
           example_group.run
+
           expect(retry_attempts).to eq(2)
         end
       end

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -89,12 +89,6 @@ describe RSpec::Retry do
           example_group.examples.first.metadata[:retry_attempts]
         end
 
-        it 'should initialize attempts metadata to 0' do
-          example_group.example { }
-          example_group.run
-          expect(retry_attempts).to eq(0)
-        end
-
         it 'should retry and match attempts metadata' do
           example_group.example do
             $count ||= 0


### PR DESCRIPTION
Simple shim to store attempted retries in the example metadata.

Purpose is to be able to reference this count in custom reporters or summary loggers.

Thanks, cheers!
