### PR TITLE
Refactor so that retry can be called programmatically

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -74,13 +74,21 @@ module RSpec
           RSpec.configuration.exceptions_to_retry
     end
 
+    def verbose_retry?
+      RSpec.configuration.verbose_retry?
+    end
+
+    def display_try_failure_messages?
+      RSpec.configuration.display_try_failure_messages?
+    end
+
     def run
       example = current_example
 
       loop do
-        if RSpec.configuration.verbose_retry?
+        if verbose_retry?
           if attempts > 0
-            message = "RSpec::Retry: #{RSpec::Retry.ordinalize(attempts + 1)} try #{example.location}"
+            message = "RSpec::Retry: #{ordinalize(attempts + 1)} try #{example.location}"
             message = "\n" + message if attempts == 1
             RSpec.configuration.reporter.message(message)
           end
@@ -101,9 +109,9 @@ module RSpec
           end
         end
 
-        if RSpec.configuration.verbose_retry? && RSpec.configuration.display_try_failure_messages?
+        if verbose_retry? && display_try_failure_messages?
           if i != (retry_count-1)
-            try_message = "#{RSpec::Retry.ordinalize(i + 1)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
+            try_message = "#{ordinalize(i + 1)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
             RSpec.configuration.reporter.message(try_message)
           end
         end
@@ -114,8 +122,10 @@ module RSpec
       end
     end
 
+    private
+
     # borrowed from ActiveSupport::Inflector
-    def self.ordinalize(number)
+    def ordinalize(number)
       if (11..13).include?(number.to_i % 100)
         "#{number}th"
       else

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -110,8 +110,8 @@ module RSpec
         end
 
         if verbose_retry? && display_try_failure_messages?
-          if i != (retry_count-1)
-            try_message = "#{ordinalize(i + 1)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
+          if attempts != (retry_count-1)
+            try_message = "#{ordinalize(attempts + 1)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
             RSpec.configuration.reporter.message(try_message)
           end
         end

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -4,7 +4,7 @@ require 'rspec_ext/rspec_ext'
 
 module RSpec
   class Retry
-    def self.apply
+    def self.setup
       RSpec.configure do |config|
         config.add_setting :verbose_retry, :default => false
         config.add_setting :default_retry_count, :default => 1
@@ -18,59 +18,99 @@ module RSpec
         # If no list of exceptions is provided and 'retry' > 1, we always retry.
         config.add_setting :exceptions_to_retry, :default => []
 
-        # context.example is deprecated, but RSpec.current_example is not
-        # available until RSpec 3.0.
-        fetch_current_example = RSpec.respond_to?(:current_example) ?
-          proc { RSpec.current_example } : proc { |context| context.example }
-
         config.around(:each) do |ex|
-          example = fetch_current_example.call(self)
+          ex.run_with_retry
+        end
+      end
+    end
 
-          retry_count = [
-            (
-              ENV['RSPEC_RETRY_RETRY_COUNT'] ||
+    attr_reader :context, :ex
+
+    def initialize(ex, opts = {})
+      @ex = ex
+      @ex.metadata.merge!(opts)
+      current_example.attempts ||= 0
+    end
+
+    # context.example is deprecated, but RSpec.current_example is not
+    # available until RSpec 3.0.
+    def current_example
+      RSpec.respond_to?(:current_example) ?
+        RSpec.current_example : @ex.example
+    end
+
+    def retry_count
+      [
+          (
+          ENV['RSPEC_RETRY_RETRY_COUNT'] ||
               ex.metadata[:retry] ||
               RSpec.configuration.default_retry_count
-            ).to_i,
-            1
-          ].max
+          ).to_i,
+          1
+      ].max
+    end
 
-          sleep_interval = ex.metadata[:retry_wait] || RSpec.configuration.default_sleep_interval
-          exceptions_to_retry = ex.metadata[:exceptions_to_retry] || RSpec.configuration.exceptions_to_retry
+    def attempts
+      current_example.attempts ||= 0
+    end
 
-          clear_lets = ex.metadata[:clear_lets_on_failure]
-          clear_lets = RSpec.configuration.clear_lets_on_failure if clear_lets.nil?
+    def attempts=(val)
+      current_example.attempts = val
+    end
 
-          retry_count.times do |i|
-            if RSpec.configuration.verbose_retry?
-              if i > 0
-                message = "RSpec::Retry: #{RSpec::Retry.ordinalize(i + 1)} try #{example.location}"
-                message = "\n" + message if i == 1
-                RSpec.configuration.reporter.message(message)
-              end
-            end
-            example.clear_exception
-            ex.run
+    def clear_lets
+      !ex.metadata[:clear_lets_on_failure].nil? ?
+          ex.metadata[:clear_lets_on_failure] :
+          RSpec.configuration.clear_lets_on_failure
+    end
 
-            break if example.exception.nil?
+    def sleep_interval
+      ex.metadata[:retry_wait] ||
+          RSpec.configuration.default_sleep_interval
+    end
 
-            if exceptions_to_retry.any?
-              break unless exceptions_to_retry.any? do |exception_klass|
-                example.exception.is_a?(exception_klass)
-              end
-            end
+    def exceptions_to_retry
+      ex.metadata[:exceptions_to_retry] ||
+          RSpec.configuration.exceptions_to_retry
+    end
 
-            if RSpec.configuration.verbose_retry? && RSpec.configuration.display_try_failure_messages?
-              if i != (retry_count-1)
-                try_message = "#{RSpec::Retry.ordinalize(i + 1)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
-                RSpec.configuration.reporter.message(try_message)
-              end
-            end
+    def run
+      example = current_example
 
-            self.clear_lets if clear_lets
-            sleep sleep_interval if sleep_interval.to_i > 0
+      loop do
+        if RSpec.configuration.verbose_retry?
+          if attempts > 0
+            message = "RSpec::Retry: #{RSpec::Retry.ordinalize(attempts + 1)} try #{example.location}"
+            message = "\n" + message if attempts == 1
+            RSpec.configuration.reporter.message(message)
           end
         end
+
+        example.clear_exception
+        ex.run
+
+        self.attempts += 1
+
+        break if example.exception.nil?
+
+        break if attempts >= retry_count
+
+        if exceptions_to_retry.any?
+          break unless exceptions_to_retry.any? do |exception_klass|
+            example.exception.is_a?(exception_klass)
+          end
+        end
+
+        if RSpec.configuration.verbose_retry? && RSpec.configuration.display_try_failure_messages?
+          if i != (retry_count-1)
+            try_message = "#{RSpec::Retry.ordinalize(i + 1)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
+            RSpec.configuration.reporter.message(try_message)
+          end
+        end
+
+        example.example_group_instance.clear_lets if clear_lets
+
+        sleep sleep_interval if sleep_interval.to_i > 0
       end
     end
 
@@ -90,4 +130,4 @@ module RSpec
   end
 end
 
-RSpec::Retry.apply
+RSpec::Retry.setup

--- a/lib/rspec_ext/rspec_ext.rb
+++ b/lib/rspec_ext/rspec_ext.rb
@@ -1,8 +1,16 @@
 module RSpec
   module Core
     class Example
+      attr_accessor :attempts
+
       def clear_exception
         @exception = nil
+      end
+
+      class Procsy
+        def run_with_retry(opts = {})
+          RSpec::Retry.new(self, opts).run
+        end
       end
     end
   end

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -120,4 +120,20 @@ describe RSpec::Retry do
       expect(let_based_on_control).to be(!@control)
     end
   end
+
+  describe 'running example.run_with_retry in an around filter', retry: 2 do
+    before(:each) { count_up }
+    before(:all) do
+      set_expectations([false, false, true])
+    end
+
+    it 'allows retry options to be overridden', :overridden do
+      expect(RSpec.current_example.metadata[:retry]).to eq(3)
+    end
+
+    it 'uses the overridden options', :overridden do
+      expect(true).to be(shift_expectation)
+      expect(count).to eq(3)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ end
 
 RSpec.configure do |config|
   config.verbose_retry = true
+  config.display_try_failure_messages = true
 
   config.around :each, :overridden do |ex|
     ex.run_with_retry retry: 3

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,4 +8,8 @@ end
 
 RSpec.configure do |config|
   config.verbose_retry = true
+
+  config.around :each, :overridden do |ex|
+    ex.run_with_retry retry: 3
+  end
 end


### PR DESCRIPTION
This allows RSpec Retry to be invoked programmatically in an around hook by calling `ex.run_with_retry(opts)`, which allows the behavior to be more customizable. Custom retry options can be passed into this method. Example:

```ruby
config.around :each, :js do |ex|
  ex.run_with_retry retry: 3
end
```

Fixes #20, #44