### PR TITLE
Retry based on example metadata

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -12,6 +12,9 @@ module RSpec
         config.add_setting :clear_lets_on_failure, :default => true
         config.add_setting :display_try_failure_messages, :default => false
 
+        # retry based on example metadata
+        config.add_setting :retry_count_condition, :default => ->(_) { nil }
+
         # If a list of exceptions is provided and 'retry' > 1, we only retry if
         # the exception that was raised by the example is NOT in that list. Otherwise
         # we ignore the 'retry' value and fail immediately.
@@ -52,6 +55,7 @@ module RSpec
           (
           ENV['RSPEC_RETRY_RETRY_COUNT'] ||
               ex.metadata[:retry] ||
+              RSpec.configuration.retry_count_condition.call(ex) ||
               RSpec.configuration.default_retry_count
           ).to_i,
           1

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -57,6 +57,15 @@ describe RSpec::Retry do
       end
     end
 
+    context 'with lambda condition' do
+      before(:all) { set_expectations([false, true]) }
+
+      it "should get retry count from condition call", retry_me_once: true do
+        expect(true).to be(shift_expectation)
+        expect(count).to eq(2)
+      end
+    end
+
     context 'with :retry => 0' do
       after(:all) { @@this_ran_once = nil }
       it 'should still run once', retry: 0 do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,6 @@ RSpec.configure do |config|
   config.around :each, :overridden do |ex|
     ex.run_with_retry retry: 3
   end
+
+  config.retry_count_condition = ->(example) { example.metadata[:retry_me_once] ? 2 : nil }
 end


### PR DESCRIPTION
The reason for this is to be able to skip retries on transactional tests which were causing DB deadlocks.

In our case only JS based tests fail randomly, so we use it this way:

```
config.retry_count_condition = ->(ex) { ex.metadata[:js] ? 3 : 1 }
```
