### PR TITLE
Retry callback option

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -83,6 +83,10 @@ module RSpec
       RSpec.configuration.display_try_failure_messages?
     end
 
+    def retry_callback
+      ex.metadata[:retry_callback]
+    end
+
     def run
       example = current_example
 

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -17,6 +17,7 @@ module RSpec
         #
         # If no list of exceptions is provided and 'retry' > 1, we always retry.
         config.add_setting :exceptions_to_retry, :default => []
+        config.add_setting :retry_callback, :default => nil
 
         config.around(:each) do |ex|
           ex.run_with_retry
@@ -119,6 +120,8 @@ module RSpec
         example.example_group_instance.clear_lets if clear_lets
 
         sleep sleep_interval if sleep_interval.to_i > 0
+
+        retry_callback[example, attempts] if retry_callback
       end
     end
 

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -84,7 +84,8 @@ module RSpec
     end
 
     def retry_callback
-      ex.metadata[:retry_callback]
+      ex.metadata[:retry_callback] ||
+        RSpec.configuration.retry_callback
     end
 
     def run


### PR DESCRIPTION
Adds a configuration option to RSpec for `retry_callback`, which takes a lambda argument allowing the user to run some logic between reruns.  I'm using it like this:

```
config.retry_callback = ->(ex, attempt) {
    return if attempt < 2
    return unless ex.exception.is_a? Capybara::Poltergeist::PageLoadTimeoutError
    include VisitationFixer; restart_phantomjs }
```
