### PR TITLE
Add formatter to print summary

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -86,8 +86,9 @@ module RSpec
       example = current_example
 
       loop do
-        if verbose_retry?
-          if attempts > 0
+        if attempts > 0
+          RSpec.configuration.formatters.each { |f| f.retry(example) if f.respond_to? :retry }
+          if verbose_retry?
             message = "RSpec::Retry: #{ordinalize(attempts + 1)} try #{example.location}"
             message = "\n" + message if attempts == 1
             RSpec.configuration.reporter.message(message)

--- a/lib/rspec/retry/formatter.rb
+++ b/lib/rspec/retry/formatter.rb
@@ -1,0 +1,54 @@
+require 'rspec/core/formatters/base_text_formatter'
+
+class RSpec::Retry::Formatter < RSpec::Core::Formatters::BaseTextFormatter
+  RSpec::Core::Formatters.register self, :example_passed
+
+  def initialize(output)
+    super(output)
+    @tries = Hash.new { |h, k| h[k] = { successes: 0, tries: 0 } }
+  end
+
+  def seed(_); end
+
+  def message(_message); end
+
+  def close(_); end
+
+  def dump_failures(_); end
+
+  def dump_summary(notification)
+    output = "\nRSpec Retry Summary:\n"
+    @tries.each do |key, retry_data|
+      next if retry_data[:successes] < 1 || retry_data[:tries] <= 1
+      output += "\t#{key.location}: #{key.full_description}: passed at attempt #{retry_data[:tries]}\n"
+    end
+    retried = @tries.count { |_, v| v[:tries] > 1  && v[:successes] > 0 }
+    output += "\n\t#{retried} of #{notification.example_count} tests passed with retries.\n"
+    output += "\t#{notification.failure_count} tests failed all retries.\n"
+    puts output
+  end
+
+  def example_passed(notification)
+    increment_success notification.example
+  end
+
+  def retry(example)
+    increment_tries example
+  end
+
+  private
+
+  def increment_success(example)
+    # debugger
+    previous = @tries[example]
+    @tries[example] = {
+      successes: previous[:successes] + 1, tries: previous[:tries] + 1 }
+  end
+
+  def increment_tries(example)
+    # debugger
+    previous = @tries[example]
+    @tries[example] = {
+      successes: previous[:successes], tries: previous[:tries] + 1 }
+  end
+end

--- a/lib/rspec/retry/formatter.rb
+++ b/lib/rspec/retry/formatter.rb
@@ -16,6 +16,8 @@ class RSpec::Retry::Formatter < RSpec::Core::Formatters::BaseTextFormatter
 
   def dump_failures(_); end
 
+  def dump_pending(_); end
+
   def dump_summary(notification)
     output = "\nRSpec Retry Summary:\n"
     @tries.each do |key, retry_data|


### PR DESCRIPTION
This adds the ability to print a retry report at the end of the test run by adding to the spec_helper:
``` ruby
RSpec.configure do |config|
  config.add_formatter RSpec::Retry::Formatter
end
```

Summary will look like this:
```
Rspec::Retry::Formatter does the job
  add random test failures in summary
  counts passing tests in summary
  counts failures in summary (FAILED - 1)
Removing DynamoDBLocal process

Failures:

  1) Rspec::Retry::Formatter does the job counts failures in summary
     Failure/Error: expect(0).to eq 1

       expected: 1
            got: 0

       (compared using ==)
     # ./spec/lib/status_spec.rb:189:in `block (2 levels) in <top (required)>'
     # ./spec/rails_helper.rb:77:in `block (3 levels) in <top (required)>'
     # ./spec/rails_helper.rb:76:in `block (2 levels) in <top (required)>'
     # -e:1:in `<main>'

Finished in 0.98055 seconds (files took 2.98 seconds to load)
3 examples, 1 failure

Failed examples:

rspec ./spec/lib/status_spec.rb:188 # Rspec::Retry::Formatter does the job counts failures in summary

RSpec Retry Summary:
	./spec/lib/status_spec.rb:179: Rspec::Retry::Formatter does the job add random test failures in summary: passed at attempt 2

	1 of 3 tests passed with retries.
	1 tests failed all retries.

Randomized with seed 46819
```