### PR TITLE
BUGFIX: fix displaying of failure messages

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -110,7 +110,7 @@ module RSpec
         end
 
         if verbose_retry? && display_try_failure_messages?
-          if attempts != (retry_count)
+          if attempts != retry_count
             try_message = "#{ordinalize(attempts)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
             RSpec.configuration.reporter.message(try_message)
           end

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -110,8 +110,8 @@ module RSpec
         end
 
         if verbose_retry? && display_try_failure_messages?
-          if attempts != (retry_count-1)
-            try_message = "#{ordinalize(attempts + 1)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
+          if attempts != (retry_count)
+            try_message = "#{ordinalize(attempts)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
             RSpec.configuration.reporter.message(try_message)
           end
         end


### PR DESCRIPTION
I had a use case of `retry_count=2` and the error messages weren't displaying.

Given the above use case - when the first attempt fails: `attempts=1` (`attempts` initialize at 0 and increment after the example is ran) and `retry_count=2`. With these values, the `try_message` will not display given the old logic. 

In addition, with higher `retry_count` values - when displaying the `try_message` - it should mention the current `attempt` number as it is that attempt which failed (not the next).