### PR TITLE
Fixed display_try_failure_message

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -110,8 +110,8 @@ module RSpec
         end
 
         if verbose_retry? && display_try_failure_messages?
-          if attempts != (retry_count-1)
-            try_message = "#{ordinalize(attempts + 1)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
+          if attempts != retry_count
+            try_message = "#{ordinalize(attempts)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
             RSpec.configuration.reporter.message(try_message)
           end
         end


### PR DESCRIPTION
`display_try_failure_message` doesn't work properly since PR #45 due to a change that increments `attempts` here: https://github.com/NoRedInk/rspec-retry/pull/45/files#diff-f42ff62e74e829479635c2f4b06b1d59R100

This PR fixes the issue.