### PR TITLE
Cope with multiple exceptions in an example

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -138,7 +138,7 @@ module RSpec
                 [example.exception.to_s]
               end
 
-            try_message = "#{ordinalize(attempts)} Try error in #{example.location}:\n #{exception_strings.join "\n"} \n"
+            try_message = "\n#{ordinalize(attempts)} Try error in #{example.location}:\n#{exception_strings.join "\n"}\n"
             RSpec.configuration.reporter.message(try_message)
           end
         end

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -131,14 +131,14 @@ module RSpec
 
         if verbose_retry? && display_try_failure_messages?
           if attempts != retry_count
-            exceptions =
+            exception_strings =
               if ::RSpec::Core::MultipleExceptionError::InterfaceTag === example.exception
                 example.exception.all_exceptions.map(&:to_s)
               else
                 [example.exception.to_s]
               end
 
-            try_message = "#{ordinalize(attempts)} Try error in #{example.location}:\n #{exceptions.join "\n"} \n"
+            try_message = "#{ordinalize(attempts)} Try error in #{example.location}:\n #{exception_strings.join "\n"} \n"
             RSpec.configuration.reporter.message(try_message)
           end
         end

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -131,7 +131,14 @@ module RSpec
 
         if verbose_retry? && display_try_failure_messages?
           if attempts != retry_count
-            try_message = "#{ordinalize(attempts)} Try error in #{example.location}:\n #{example.exception.to_s} \n"
+            exceptions =
+              if ::RSpec::Core::MultipleExceptionError::InterfaceTag === example.exception
+                example.exception.all_exceptions.map(&:to_s)
+              else
+                [example.exception.to_s]
+              end
+
+            try_message = "#{ordinalize(attempts)} Try error in #{example.location}:\n #{exceptions.join "\n"} \n"
             RSpec.configuration.reporter.message(try_message)
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'rspec'
+require 'rspec/core/sandbox'
+
 require 'rspec/retry'
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2')
   require "pry-debugger"
@@ -9,6 +11,13 @@ end
 RSpec.configure do |config|
   config.verbose_retry = true
   config.display_try_failure_messages = true
+
+  config.around :example do |ex|
+    RSpec::Core::Sandbox.sandboxed do |config|
+      RSpec::Retry.setup
+      ex.run
+    end
+  end
 
   config.around :each, :overridden do |ex|
     ex.run_with_retry retry: 3


### PR DESCRIPTION
RSpec has the ability to wrap multiple exceptions into one when running tests, this can come from either the new(ish) `aggregate_failures` functionality, or from errors arising in hooks in failing tests...

Rather than just plainly print these out it might be nicer to output each one.