### PR TITLE
allow to use rspec 3.5.x

### DIFF
--- a/rspec-retry.gemspec
+++ b/rspec-retry.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "rspec-retry"
   gem.require_paths = ["lib"]
   gem.version       = RSpec::Retry::VERSION
-  gem.add_runtime_dependency(%{rspec-core}, '>3.3', '<=3.5')
+  gem.add_runtime_dependency(%{rspec-core}, '>3.3', '<3.6')
   gem.add_development_dependency %q{appraisal}
   gem.add_development_dependency %q{rspec}
   gem.add_development_dependency %q{guard-rspec}


### PR DESCRIPTION
`<=3.5` is only allow `3.5.0`. I think the patch version of the update may be to be able to, how about?