### PR TITLE
Adding license info to the gemspec.

### DIFF
--- a/rspec-retry.gemspec
+++ b/rspec-retry.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{retry intermittently failing rspec examples}
   gem.summary       = %q{retry intermittently failing rspec examples}
   gem.homepage      = "http://github.com/NoRedInk/rspec-retry"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.
