### PR TITLE
Add `retry_callback` to allow for custom cleanup between retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ RSpec.configure do |config|
   config.around :each, :js do |ex|
     ex.run_with_retry retry: 3
   end
+
+  # callback to be run between retries  
+  config.retry_callback = proc do |ex|
+    # run some additional clean up task - can be filtered by example metadata
+    if ex.metadata[:js]
+      Capybara.reset!     
+    end
+  end
 end
 ```
 
@@ -73,6 +81,8 @@ You can call `ex.run_with_retry(opts)` on an individual example.
 - __:clear_lets_on_failure__(default: *true*) Clear memoized values for ``let``s before retrying
 - __:exceptions_to_hard_fail__(default: *[]*) List of exceptions that will trigger an immediate test failure without retry. Takes precedence over __:exceptions_to_retry__
 - __:exceptions_to_retry__(default: *[]*) List of exceptions that will trigger a retry (when empty, all exceptions will)
+- __:retry_callback__(default: *nil*) Callback function to be called between retries
+
 
 ## Environment Variables
 - __RSPEC_RETRY_RETRY_COUNT__ can override the retry counts even if a retry count is set in an example or default_retry_count is set in a configuration.

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -26,6 +26,9 @@ module RSpec
         # If no list of exceptions is provided and 'retry' > 1, we always retry.
         config.add_setting :exceptions_to_retry, :default => []
 
+        # Callback between retries
+        config.add_setting :retry_callback, :default => nil
+
         config.around(:each) do |ex|
           ex.run_with_retry
         end
@@ -144,6 +147,11 @@ module RSpec
         end
 
         example.example_group_instance.clear_lets if clear_lets
+
+        # If the callback is defined, let's call it
+        if RSpec.configuration.retry_callback
+          example.example_group_instance.instance_exec(example, &RSpec.configuration.retry_callback)
+        end
 
         sleep sleep_interval if sleep_interval.to_i > 0
       end

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -202,6 +202,45 @@ describe RSpec::Retry do
     end
   end
 
+  describe 'calling retry_callback between retries', retry: 2 do
+    before(:all) do
+      RSpec.configuration.retry_callback = proc do |example|
+        @control = false
+        @example = example
+      end
+    end
+
+    after(:all) do
+      RSpec.configuration.retry_callback = nil
+    end
+
+    context 'should call retry_callback' do
+      before(:all) do
+        @control = true
+        @example = nil
+      end
+
+      it do |example|
+        expect(@control).to be(false)
+        expect(@example).to eq(example)
+      end
+    end
+
+    context 'does not call retry_callback if no errors' do
+      before(:all) do
+        @control = true
+        @example = nil
+      end
+
+      after do
+        expect(@control).to be(true)
+        expect(@example).to be_nil
+      end
+
+      it { true }
+    end
+  end
+
   describe 'output in verbose mode' do
 
     line_1 = __LINE__ + 8


### PR DESCRIPTION
The idea is that there may be clean up tasks (besides flushing the `let`s). This would allow users to configure a block that would be run between each retry; for example flushing out the database).

```
RSpec.configure do |config|
  config.retry_callback = proc do
    puts "\n#### Forcing database truncation ####".cyan
    DatabaseCleaner.clean_with(:truncation)
  end
end
```

My use case is that by default a `transaction` database clean is used, however there are occasions where this falls over itself due to asynchronous resource locking where a spec succeeds but the DB resources are left behind.

Rather than switching for a full truncation method between specs, it would be much nicer if we could *somewhat* identify these and just run the full flush when needed.

Thoughts?