### PR TITLE
Update README to include caveat of auto require

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ RSpec.configure do |config|
 end
 ```
 
+RSpec::Retry will load automatically for feature tests once included. Frameworks like Rails will
+automatically include gems for a certain environment. If you want to prevent RSpec::Retry from
+loading automatically, use:
+
+    gem 'rspec-retry', require: nil
+    
+Now RSpec::Retry will only load once explicitly required.
+
 ## Usage
 
 ```ruby


### PR DESCRIPTION
I ran into this bug where I saw the RSpec::Retry code wrapping our examples in our non-feature test suite. While it doesn't execute except for JS tests, it was a confusing and unexpected behavior. I wanted to document it for future developers.

This is a really old PR that I had botched (see https://github.com/sb8244/rspec-retry/pull/1), so I'm finally moving it to this repo.