### PR TITLE
Add ability to match errors on case equality

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -121,15 +121,11 @@ module RSpec
         break if attempts >= retry_count
 
         if exceptions_to_hard_fail.any?
-          break if exceptions_to_hard_fail.any? do |exception_klass|
-            example.exception.is_a?(exception_klass)
-          end
+          break if exception_exists_in?(exceptions_to_hard_fail, example.exception)
         end
 
         if exceptions_to_retry.any?
-          break unless exceptions_to_retry.any? do |exception_klass|
-            example.exception.is_a?(exception_klass)
-          end
+          break unless exception_exists_in?(exceptions_to_retry, example.exception)
         end
 
         if verbose_retry? && display_try_failure_messages?
@@ -170,6 +166,12 @@ module RSpec
         when 3; "#{number}rd"
         else    "#{number}th"
         end
+      end
+    end
+
+    def exception_exists_in?(list, exception)
+      list.any? do |exception_klass|
+        exception.is_a?(exception_klass) || exception_klass === exception
       end
     end
   end

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -23,9 +23,8 @@ describe RSpec::Retry do
   class RetryChildError < RetryError; end
   class HardFailError < StandardError; end
   class HardFailChildError < HardFailError; end
-  class OtherError < StandardError; end;
-  class SharedError < StandardError; end;
-
+  class OtherError < StandardError; end
+  class SharedError < StandardError; end
   before(:all) do
     ENV.delete('RSPEC_RETRY_RETRY_COUNT')
   end
@@ -128,6 +127,20 @@ describe RSpec::Retry do
         it "only runs once" do
           set_expectations([false])
           expect(count).to eq(1)
+        end
+      end
+
+      context 'the example retries exceptions which match with case equality' do
+        class CaseEqualityError < StandardError
+          def self.===(other)
+            # An example of dynamic matching
+            other.message == 'Rescue me!'
+          end
+        end
+
+        it 'retries the maximum number of times', exceptions_to_retry: [CaseEqualityError] do
+          raise StandardError, 'Rescue me!' unless count > 1
+          expect(count).to eq(2)
         end
       end
     end


### PR DESCRIPTION
The semantics of `rspec-retry`'s rescuing are a bit different than ruby's rescue. Ruby will rescue classes based on the case equality operator as well (`===`). [This blog post describes is very well](http://blog.honeybadger.io/level-up-ruby-rescue-with-dynamic-exception-matchers/)

With this PR, users will be able to dynamically retry on errors.

Let me know if you have any thoughts 😄 