### PR TITLE
Remove <3.8 constraint on rspec-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ rvm:
   - 2.1
   - 2.2
   - 2.3.3
-  - 2.4.0
+  - 2.4.3
+  - 2.5.0
 gemfile:
   - gemfiles/rspec_3.3.gemfile
   - gemfiles/rspec_3.4.gemfile

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ specified number of times until the example succeeds.
 
 | Rspec Version | Rspec-Retry Version |
 |---------------|---------------------|
-| 3.3>          | 0.5.7               |
+| > 3.3         | 0.5.7               |
 | 3.2           | 0.4.6               |
 | 2.14.8        | 0.4.4               |
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ specified number of times until the example succeeds.
 
 | Rspec Version | Rspec-Retry Version |
 |---------------|---------------------|
-| 3.3-3.7       | 0.5.6               |
+| 3.3>          | 0.5.7               |
 | 3.2           | 0.4.6               |
 | 2.14.8        | 0.4.4               |
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.5.7 - 2018-03-13
+## enhancements
+remove <3.8 constraint on rspec-core to prevent breaking when rspec-core upgrades
+
 # 0.5.6 - 2017-10-17
 ## enhancements
 added support for rspec 3.7.0

--- a/gemfiles/rspec_3.3.gemfile.lock
+++ b/gemfiles/rspec_3.3.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    rspec-retry (0.5.6)
-      rspec-core (> 3.3, < 3.8)
+    rspec-retry (0.5.7)
+      rspec-core (> 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec-retry!
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/gemfiles/rspec_3.4.gemfile.lock
+++ b/gemfiles/rspec_3.4.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    rspec-retry (0.5.6)
-      rspec-core (> 3.3, < 3.8)
+    rspec-retry (0.5.7)
+      rspec-core (> 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec-retry!
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/gemfiles/rspec_3.5.gemfile.lock
+++ b/gemfiles/rspec_3.5.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    rspec-retry (0.5.6)
-      rspec-core (> 3.3, < 3.8)
+    rspec-retry (0.5.7)
+      rspec-core (> 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec-retry!
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/gemfiles/rspec_3.6.gemfile.lock
+++ b/gemfiles/rspec_3.6.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    rspec-retry (0.5.6)
-      rspec-core (> 3.3, < 3.8)
+    rspec-retry (0.5.7)
+      rspec-core (> 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -50,4 +50,4 @@ DEPENDENCIES
   rspec-retry!
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/gemfiles/rspec_3.7.gemfile.lock
+++ b/gemfiles/rspec_3.7.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ..
   specs:
-    rspec-retry (0.5.6)
-      rspec-core (> 3.3, < 3.8)
+    rspec-retry (0.5.7)
+      rspec-core (> 3.3)
 
 GEM
   remote: https://rubygems.org/
@@ -48,4 +48,4 @@ DEPENDENCIES
   rspec-retry!
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/lib/rspec/retry/version.rb
+++ b/lib/rspec/retry/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   class Retry
-    VERSION = "0.5.6"
+    VERSION = "0.5.7"
   end
 end

--- a/rspec-retry.gemspec
+++ b/rspec-retry.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.name          = "rspec-retry"
   gem.require_paths = ["lib"]
   gem.version       = RSpec::Retry::VERSION
-  gem.add_runtime_dependency(%{rspec-core}, '>3.3', '<3.8')
+  gem.add_runtime_dependency(%{rspec-core}, '>3.3')
   gem.add_development_dependency %q{appraisal}
   gem.add_development_dependency %q{rspec}
   gem.add_development_dependency %q{byebug}, '~>9.0.6' # 9.1 deprecates ruby 2.1


### PR DESCRIPTION
@michaelglass This PR is to prevent builds from breaking when rspec-core upgrades. I think it would be preferable to add testing as new rspec versions come out, but not hard block the upgrade with a constraint.