### PR TITLE
Adds exponential backoff option to sleep interval

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -9,6 +9,7 @@ module RSpec
         config.add_setting :verbose_retry, :default => false
         config.add_setting :default_retry_count, :default => 1
         config.add_setting :default_sleep_interval, :default => 0
+        config.add_setting :exponential_backoff, :default => false
         config.add_setting :clear_lets_on_failure, :default => true
         config.add_setting :display_try_failure_messages, :default => false
 
@@ -76,8 +77,12 @@ module RSpec
     end
 
     def sleep_interval
-      ex.metadata[:retry_wait] ||
-          RSpec.configuration.default_sleep_interval
+      if ex.metadata[:exponential_backoff]
+          2**(current_example.attempts-1) * ex.metadata[:retry_wait]
+      else
+          ex.metadata[:retry_wait] ||
+              RSpec.configuration.default_sleep_interval
+      end
     end
 
     def exceptions_to_hard_fail

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -83,6 +83,17 @@ describe RSpec::Retry do
       end
     end
 
+    context "with exponential backoff enabled", :retry => 3, :retry_wait => 5, :exponential_backoff => true do
+      context do
+        before(:all) { set_expectations([false, false, true]) }
+
+        it 'should run example until :retry times', :retry => 3 do
+          expect(true).to be(shift_expectation)
+          expect(count).to eq(3)
+        end
+      end
+    end
+
     describe "with a list of exceptions to immediately fail on", :retry => 2, :exceptions_to_hard_fail => [HardFailError] do
       context "the example throws an exception contained in the hard fail list" do
         it "does not retry" do


### PR DESCRIPTION
Having exponential backoff would be nice as we're having a similar problem to [this issue](https://github.com/NoRedInk/rspec-retry/issues/91).

Let me know if you'd like testing around this, there currently isn't any around `:retry_wait` either.