### PR TITLE
Aeberlin store attempted retries in example metadata

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -121,7 +121,7 @@ module RSpec
         end
 
         example.metadata[:retry_attempts] = self.attempts
-        # require 'pry'; binding.pry
+
         example.clear_exception
         ex.run
 

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -50,7 +50,7 @@ module RSpec
     # context.example is deprecated, but RSpec.current_example is not
     # available until RSpec 3.0.
     def current_example
-      RSpec.respond_to?(:current_example) ?
+      @current_example ||= RSpec.respond_to?(:current_example) ?
         RSpec.current_example : @ex.example
     end
 
@@ -120,6 +120,8 @@ module RSpec
           end
         end
 
+        example.metadata[:retry_attempts] = self.attempts
+        # require 'pry'; binding.pry
         example.clear_exception
         ex.run
 

--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -47,11 +47,8 @@ module RSpec
       current_example.attempts ||= 0
     end
 
-    # context.example is deprecated, but RSpec.current_example is not
-    # available until RSpec 3.0.
     def current_example
-      @current_example ||= RSpec.respond_to?(:current_example) ?
-        RSpec.current_example : @ex.example
+      @current_example ||= RSpec.current_example
     end
 
     def retry_count

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -149,15 +149,7 @@ describe RSpec::Retry do
           $count, $example_code = 0, example_code
 
           RSpec.describe("example group", exceptions_to_retry: [NameError], retry: 3).tap do |this|
-            if rspec_version =~ /^3\.2/
-              this.instance_eval %{
-                it 'intentionally raises an error' do
-                  #{$example_code}
-                end
-              }
-            else
-              this.run # initialize for rspec 3.3+ with no examples
-            end
+            this.run # initialize for rspec 3.3+ with no examples
           end
         end
 
@@ -166,10 +158,7 @@ describe RSpec::Retry do
         end
 
         it 'should retry and match attempts metadata' do
-          unless rspec_version =~ /^3\.2/
-            example_group.example { instance_eval($example_code) }
-          end
-
+          example_group.example { instance_eval($example_code) }
           example_group.run
 
           expect(retry_attempts).to eq(2)

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -133,6 +133,35 @@ describe RSpec::Retry do
     end
 
     describe "with a list of exceptions to retry on", :retry => 2, :exceptions_to_retry => [RetryError] do
+      context do
+        let(:example_group) do
+          RSpec.describe('example group', exceptions_to_retry: [NameError], retry: 3).tap do |this|
+            this.run # initialize rspec-retry inside test example group
+          end
+        end
+
+        let(:retry_attempts) do
+          example_group.examples.first.metadata[:retry_attempts]
+        end
+
+        it 'should initialize attempts metadata to 0' do
+          example_group.example { }
+          example_group.run
+          expect(retry_attempts).to eq(0)
+        end
+
+        it 'should retry and match attempts metadata' do
+          example_group.example do
+            $count ||= 0
+            $count += 1
+            raise NameError unless $count > 2
+          end
+
+          example_group.run
+          expect(retry_attempts).to eq(2)
+        end
+      end
+
       context "the example throws an exception contained in the retry list" do
         it "retries the maximum number of times" do
           raise RetryError unless count > 1

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -134,9 +134,30 @@ describe RSpec::Retry do
 
     describe "with a list of exceptions to retry on", :retry => 2, :exceptions_to_retry => [RetryError] do
       context do
-        let(:example_group) do
-          RSpec.describe('example group', exceptions_to_retry: [NameError], retry: 3).tap do |this|
-            this.run # initialize rspec-retry inside test example group
+        let(:rspec_version) { RSpec::Core::Version::STRING }
+
+        let(:example_code) do
+          %{
+            $count ||= 0
+            $count += 1
+
+            raise NameError unless $count > 2
+          }
+        end
+
+        let!(:example_group) do
+          $count, $example_code = 0, example_code
+
+          RSpec.describe("example group", exceptions_to_retry: [NameError], retry: 3).tap do |this|
+            if rspec_version =~ /^3\.2/
+              this.instance_eval %{
+                it 'intentionally raises an error' do
+                  #{$example_code}
+                end
+              }
+            else
+              this.run # initialize for rspec 3.3+ with no examples
+            end
           end
         end
 
@@ -145,13 +166,12 @@ describe RSpec::Retry do
         end
 
         it 'should retry and match attempts metadata' do
-          example_group.example do
-            $count ||= 0
-            $count += 1
-            raise NameError unless $count > 2
+          unless rspec_version =~ /^3\.2/
+            example_group.example { instance_eval($example_code) }
           end
 
           example_group.run
+
           expect(retry_attempts).to eq(2)
         end
       end

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -144,12 +144,6 @@ describe RSpec::Retry do
           example_group.examples.first.metadata[:retry_attempts]
         end
 
-        it 'should initialize attempts metadata to 0' do
-          example_group.example { }
-          example_group.run
-          expect(retry_attempts).to eq(0)
-        end
-
         it 'should retry and match attempts metadata' do
           example_group.example do
             $count ||= 0


### PR DESCRIPTION
replacement for https://github.com/NoRedInk/rspec-retry/pull/43