### PR TITLE
Expose RSpec::Core::Example#attempts via Procsy

### DIFF
--- a/lib/rspec_ext/rspec_ext.rb
+++ b/lib/rspec_ext/rspec_ext.rb
@@ -11,6 +11,10 @@ module RSpec
         def run_with_retry(opts = {})
           RSpec::Retry.new(self, opts).run
         end
+
+        def attempts
+          @example.attempts
+        end
       end
     end
   end

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -319,6 +319,37 @@ describe RSpec::Retry do
     end
   end
 
+  describe 'Example::Procsy#attempts' do
+    let!(:example_group) do
+      RSpec.describe do
+        before :all do
+          @@results = {}
+        end
+
+        around do |example|
+          example.run_with_retry
+          @@results[example.description] = [example.exception.nil?, example.attempts]
+        end
+
+        specify 'without retry option' do
+          expect(true).to be(true)
+        end
+
+        specify 'with retry option', retry: 3 do
+          expect(true).to be(false)
+        end
+      end
+    end
+
+    it 'should be exposed' do
+      example_group.run
+      expect(example_group.class_variable_get(:@@results)).to eq({
+        'without retry option' => [true, 1],
+        'with retry option' => [false, 3]
+      })
+    end
+  end
+
   describe 'output in verbose mode' do
 
     line_1 = __LINE__ + 8


### PR DESCRIPTION
This is useful for around/after hooks to check how many retries are actually attempted.