### PR TITLE
CI: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,3 @@ gemfile:
   - gemfiles/rspec_3.6.gemfile
   - gemfiles/rspec_3.7.gemfile
 cache: bundler
-sudo: false


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).