### PR TITLE
Expose retry exceptions to example metadata

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -118,6 +118,7 @@ module RSpec
         end
 
         example.metadata[:retry_attempts] = self.attempts
+        example.metadata[:retry_exceptions] ||= []
 
         example.clear_exception
         ex.run
@@ -125,6 +126,8 @@ module RSpec
         self.attempts += 1
 
         break if example.exception.nil?
+
+        example.metadata[:retry_exceptions] << example.exception
 
         break if attempts >= retry_count
 

--- a/spec/lib/rspec/retry_spec.rb
+++ b/spec/lib/rspec/retry_spec.rb
@@ -163,6 +163,19 @@ describe RSpec::Retry do
 
           expect(retry_attempts).to eq(2)
         end
+
+        let(:retry_exceptions) do
+          example_group.examples.first.metadata[:retry_exceptions]
+        end
+
+        it 'should add exceptions into retry_exceptions metadata array' do
+          example_group.example { instance_eval($example_code) }
+          example_group.run
+
+          expect(retry_exceptions.count).to eq(2)
+          expect(retry_exceptions[0].class).to eq NameError
+          expect(retry_exceptions[1].class).to eq NameError
+        end
       end
 
       context "the example throws an exception contained in the retry list" do


### PR DESCRIPTION
The number of attempts is already exposed via `example.metadata[:retry_attempts]` but you can't get access to the actual spec failure exception. 

This PR exposes that through the metadata `example.metadata[:retry_exceptions]`.