### PR TITLE
fix travis ruby versions and add ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - 2.3.3
-  - 2.4.3
-  - 2.5.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 gemfile:
   - gemfiles/rspec_3.3.gemfile
   - gemfiles/rspec_3.4.gemfile


### PR DESCRIPTION
travis couldn't find ruby 2.5.0 so loosened the patch specficiation