### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/rspec-retry.gemspec
+++ b/rspec-retry.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["mike@noredink.com"]
   gem.description   = %q{retry intermittently failing rspec examples}
   gem.summary       = %q{retry intermittently failing rspec examples}
-  gem.homepage      = "http://github.com/NoRedInk/rspec-retry"
+  gem.homepage      = "https://github.com/NoRedInk/rspec-retry"
   gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/rspec-retry or some tools or APIs that use the gem's metadata.