### PR TITLE
gemspec: Expose 0 executables explicitly

### DIFF
--- a/rspec-retry.gemspec
+++ b/rspec-retry.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.executables   = []
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = "rspec-retry"
   gem.require_paths = ["lib"]


### PR DESCRIPTION
This PR changes the gemspec to be more explicit: this gem exposes 0 executables.