### PR TITLE
CI: Use build matrix 2.6-3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: ruby
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
+  - "2.6"
+  - "2.7"
+  - "3.0"
 gemfile:
   - gemfiles/rspec_3.3.gemfile
   - gemfiles/rspec_3.4.gemfile


### PR DESCRIPTION
https://www.ruby-lang.org/en/downloads/branches/

Even 2.5 is EOL, so this takes us to the supported versions.