### PR TITLE
Add `require: false` to Gemfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you open an issue here to let us know about your fork, we can add a link to i
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'rspec-retry', group: :test # Unlike rspec, this doesn't need to be included in development group
+gem 'rspec-retry', require: false, group: :test # Unlike rspec, this doesn't need to be included in development group
 ```
 
 And then execute:


### PR DESCRIPTION
If you run `require 'rspec/core'` before the appropriate timing, `Kernel.#context` would be defined unexpectedly and you will get a warning when you load irb. The following Issue provides more information on this issue.

- https://github.com/rspec/rspec-rails/issues/1645

This Gem executes `require 'rspec/core'` when loaded, so if it is loaded in a Rails app with `Bundler.require` it will cause this problem. This pull request solves this problem.

https://github.com/NoRedInk/rspec-retry/blob/06a9595f7c72d8747f4dfa037e84ba9c009f30cc/lib/rspec/retry.rb#L1

```
$ bin/rails c -e test
Loading test environment (Rails 7.0.4)
irb: warn: can't alias context from irb_context.
irb(main):001:0> exit
````

Since the README already explains to write `require 'rspec/retry'`, there is no problem to explain to add `require: false` like this.