### PR TITLE
Additional exponential backoff support

### DIFF
--- a/lib/rspec/retry.rb
+++ b/lib/rspec/retry.rb
@@ -78,13 +78,12 @@ module RSpec
     end
 
     def sleep_interval
-      if ex.metadata[:exponential_backoff]
-          2**(current_example.attempts-1) * ex.metadata[:retry_wait]
+      if ex.metadata[:exponential_backoff] || RSpec.configuration.exponential_backoff
+        2**(current_example.attempts-1) * (ex.metadata[:retry_wait] || RSpec.configuration.default_sleep_interval)
       else
-          ex.metadata[:retry_wait] ||
-              RSpec.configuration.default_sleep_interval
+        ex.metadata[:retry_wait] || RSpec.configuration.default_sleep_interval
       end
-    end
+    end    
 
     def exceptions_to_hard_fail
       ex.metadata[:exceptions_to_hard_fail] ||


### PR DESCRIPTION
Allow for `RSpec.configuration.exponential_backoff` as well as `RSpec.configuration.default_sleep_interval` to be used for exponential backoff as previously only example meta data was working to use exponential backoff.